### PR TITLE
Add support for the new PTCGO export format with leading zeroes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.3.1
+
+- Bugfix to support the new PTCGO export format with leading zeroes
+
 ## 1.3.0
 
 - Add support for Crown Zenith Galarian Gallery

--- a/subset.js
+++ b/subset.js
@@ -25,12 +25,12 @@ function getSubsettedNumber(ptcgoCode, number) {
     const subset = subsets[ptcgoCode];
     let { total, prefix, leftPad } = subset;
     if (number <= total) {
-      return number.toString();
+      return number.toString().replace(/^0+/, "");
     }
     let newNumber = number - total;
     return `${prefix}${newNumber.toString().padStart(leftPad, "0")}`;
   } else {
-    return number.toString();
+    return number.toString().replace(/^0+/, "");
   }
 }
 

--- a/tests/index.html
+++ b/tests/index.html
@@ -116,7 +116,7 @@
           </tr>
           <tr>
             <td><img src="imgs/sit-70.png" /></td>
-            <td>SIT 70</td>
+            <td>SIT 070</td>
           </tr>
           <tr>
             <td><img src="imgs/sit-219.png" /></td>


### PR DESCRIPTION
After creating 1.3.0, I realized that Pokemon TCG Online had changed its export format to include leading zeroes in the card numbers.

What used to be `LOT 80` is now `LOT 080`.

This bug fix makes the extension to work on both