### PR TITLE
Update to work with Paldea Evolved (PAL) cards

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.5.0
+
+- Add support for Scarlet & Violet: Paldea Evolved (PAL) cards
+
 ## 1.4.0
 
 - Add support for Scarlet & Violet (SVI) cards

--- a/background.js
+++ b/background.js
@@ -8,6 +8,8 @@ browser.runtime.onMessage.addListener(async (message) => {
     let fullUrl;
     if (set === "SVI") {
       fullUrl = `${API_URL}cards?q=set.id:sv1%20number:${number}`;
+    } else if (set === "PAL") {
+      fullUrl = `${API_URL}cards?q=set.id:sv2%20number:${number}`;
     } else {
       fullUrl = `${API_URL}cards?q=set.ptcgoCode:${set}%20number:${number}`;
     }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "pokemon-tcg-ext",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Hover over a Pokemon TCG card ID to see the card image – anywhere in the web",
   "icons": {
     "48": "icons/48.png"


### PR DESCRIPTION
This version will be available at https://addons.mozilla.org/en-US/firefox/addon/pokemon-tcg-card-viewer/ once it's approved by Mozilla.